### PR TITLE
Fix DTO key name and improve user retrieval

### DIFF
--- a/DTO/UserDto.php
+++ b/DTO/UserDto.php
@@ -79,7 +79,7 @@ class UserDto
             $data['user']       ?? '',
             (int)($data['pos_x'] ?? 0),
             (int)($data['pos_y'] ?? 0),
-            (int)($data['exileMarkCount'] ?? 0),
+            (int)($data['exile_mark_count'] ?? 0),
             DiceDto::fromJson($data['dice'] ?? '{}'),
             new DateTimeImmutable($data['joined_at'] ?? 'now'),
         );

--- a/Service/Rule.php
+++ b/Service/Rule.php
@@ -21,7 +21,7 @@ class Rule
      */
     public function isExileCondition(RoomDto $room, UserDto $user, UserDao $userDao): bool
     {
-        $topColor = $user->getDice()->getFrontColor();
+        $topColor = $user->getDice()->getTopColor();
 
         $cell      = $room->getTiles()[$user->getPosX()][$user->getPosY()] ?? [];
         $cellColor = $cell['color'] ?? null;

--- a/Service/User.php
+++ b/Service/User.php
@@ -59,7 +59,7 @@ class User
                     }
 
                     $userData = $redis->hgetall($key);
-                    if (!empty($userData['pos_x']) && !empty($userData['pos_y'])) {
+                    if (isset($userData['pos_x']) && isset($userData['pos_y'])) {
                         $player += [
                             $userId => [
                                 'pos_x'   => $userData['pos_x'],


### PR DESCRIPTION
## Summary
- fix detection of player coordinates when 0
- use consistent key name for `exile_mark_count`
- correct rule check for top color

## Testing
- `php -l Service/User.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0ad5f6c8325b6216912ed7f7885