### PR TITLE
Implement GameService and Ratchet server

### DIFF
--- a/Service/GameService.php
+++ b/Service/GameService.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Service;
+
+use Predis\Client;
+use DTO\RoomDto;
+use DTO\UserDto;
+use DAO\RoomDao;
+use DAO\UserDao;
+
+class GameService
+{
+    private Client $redis;
+    private RoomDao $roomDao;
+    private UserDao $userDao;
+    private RuleEngine $ruleEngine;
+
+    public function __construct(Client $redis, RoomDao $roomDao, UserDao $userDao, RuleEngine $ruleEngine)
+    {
+        $this->redis = $redis;
+        $this->roomDao = $roomDao;
+        $this->userDao = $userDao;
+        $this->ruleEngine = $ruleEngine;
+    }
+
+    /**
+     * Start a turn for the given room. Sets timeout key and broadcasts event.
+     */
+    public function startTurn(string $roomId): void
+    {
+        $turnOrderKey = "room:{$roomId}:turn_order";
+        $current = $this->redis->lindex($turnOrderKey, 0);
+        if ($current === null) {
+            $users = $this->userDao->findAllByRoomId($roomId);
+            foreach (array_keys($users) as $uid) {
+                $this->redis->rpush($turnOrderKey, $uid);
+            }
+            $current = $this->redis->lindex($turnOrderKey, 0);
+        }
+
+        if ($current === null) {
+            return;
+        }
+
+        $this->redis->hset("room:{$roomId}:turn", "current_turn_user_id", $current);
+        $this->redis->setex("room:{$roomId}:turn_timer", 30, $current);
+        $this->broadcast($roomId, 'TurnStarted', ['userId' => $current]);
+    }
+
+    /**
+     * Handle a move action from a player and update states
+     */
+    public function playMove(string $roomId, string $userId, string $direction): void
+    {
+        $current = $this->redis->hget("room:{$roomId}:turn", "current_turn_user_id");
+        if ($current !== $userId) {
+            throw new \RuntimeException('Not your turn');
+        }
+
+        $room = $this->roomDao->findByRoomId((int)$roomId);
+        $user = $this->userDao->findByRoomAndUserId($roomId, $userId);
+        $all  = $this->userDao->findAllByRoomId($roomId);
+
+        if (!$room || !$user) {
+            throw new \RuntimeException('Invalid game state');
+        }
+
+        if (!$this->ruleEngine->validateMove($room, $user, $direction, $all)) {
+            throw new \RuntimeException('Move blocked by rules');
+        }
+
+        // 실제 이동 로직은 간단히 주사위 앞면 색 기준 한 칸 이동만 처리
+        $dx = 0; $dy = 0;
+        switch ($direction) {
+            case 'up':    $dy = -1; break;
+            case 'down':  $dy = 1;  break;
+            case 'left':  $dx = -1; break;
+            case 'right': $dx = 1;  break;
+        }
+
+        $newX = $user->getPosX() + $dx;
+        $newY = $user->getPosY() + $dy;
+
+        $updated = new UserDto(
+            $user->getRoomId(),
+            $user->getUserId(),
+            $newX,
+            $newY,
+            $user->getExileMarkCount(),
+            $user->getDice(),
+            $user->getJoinedAt()
+        );
+        $this->userDao->save($updated);
+
+        $this->broadcast($roomId, 'DiceMoved', [
+            'userId' => $userId,
+            'x' => $newX,
+            'y' => $newY,
+        ]);
+
+        $this->handleTimeout($roomId);
+    }
+
+    /**
+     * Rotate turn when timer expires
+     */
+    public function handleTimeout(string $roomId): void
+    {
+        $turnOrderKey = "room:{$roomId}:turn_order";
+        $next = $this->redis->rpoplpush($turnOrderKey, $turnOrderKey);
+        if ($next === null) {
+            return;
+        }
+        $this->redis->hset("room:{$roomId}:turn", "current_turn_user_id", $next);
+        $this->redis->setex("room:{$roomId}:turn_timer", 30, $next);
+        $this->broadcast($roomId, 'TurnStarted', ['userId' => $next]);
+    }
+
+    private function broadcast(string $roomId, string $type, array $payload): void
+    {
+        $channel = "room:{$roomId}:events";
+        $data = json_encode(['type' => $type, 'payload' => $payload]);
+        $this->redis->publish($channel, $data);
+    }
+}
+

--- a/Service/RuleEngine.php
+++ b/Service/RuleEngine.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Service;
+
+use DTO\RoomDto;
+use DTO\UserDto;
+use DAO\RoomDao;
+
+class RuleEngine
+{
+    /**
+     * Validate move against all rules.
+     */
+    public function validateMove(RoomDto $room, UserDto $user, string $direction, array $allUsers): bool
+    {
+        if (!$this->noSameColorInNine($room, $user, $allUsers)) {
+            return false;
+        }
+        if ($this->threeOrMoreInNine($room, $user, $allUsers)) {
+            return false;
+        }
+        if ($this->yellowSpecial($room, $user, $allUsers)) {
+            return false;
+        }
+        if ($this->lineOfThree($room, $user, $allUsers)) {
+            return false;
+        }
+        if ($this->hiddenEight($room, $user, $allUsers)) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Hidden rule #4 */
+    public function noSameColorInNine(RoomDto $room, UserDto $user, array $allUsers): bool
+    {
+        $grid = $room->getTiles();
+        foreach ($allUsers as $u) {
+            $grid[$u->getPosX()][$u->getPosY()]['color'] = $u->getDice()->getFrontColor();
+        }
+        $neighbors = $room->getNeighbors([$user->getPosX(), $user->getPosY()], 1);
+        $color = $user->getDice()->getFrontColor();
+        foreach ($neighbors as [$x, $y]) {
+            if (($grid[$x][$y]['color'] ?? null) === $color) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Hidden rule #5 */
+    public function threeOrMoreInNine(RoomDto $room, UserDto $user, array $allUsers): bool
+    {
+        $grid = $room->getTiles();
+        foreach ($allUsers as $u) {
+            $grid[$u->getPosX()][$u->getPosY()]['color'] = $u->getDice()->getFrontColor();
+        }
+        $neighbors = $room->getNeighbors([$user->getPosX(), $user->getPosY()], 1);
+        $color = $user->getDice()->getFrontColor();
+        $count = 0;
+        foreach ($neighbors as [$x, $y]) {
+            if (($grid[$x][$y]['color'] ?? null) === $color) {
+                if (++$count >= 3) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Hidden rule #6 */
+    public function yellowSpecial(RoomDto $room, UserDto $user, array $allUsers): bool
+    {
+        if ($user->getDice()->getFrontColor() !== 'yellow') {
+            return false;
+        }
+        $grid = $room->getTiles();
+        foreach ($allUsers as $u) {
+            $grid[$u->getPosX()][$u->getPosY()]['color'] = $u->getDice()->getFrontColor();
+        }
+        $neighbors = $room->getNeighbors([$user->getPosX(), $user->getPosY()], 1);
+        $count = 0;
+        foreach ($neighbors as [$x, $y]) {
+            if (isset($grid[$x][$y]['color'])) {
+                if (++$count >= 3) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Hidden rule #7 */
+    public function lineOfThree(RoomDto $room, UserDto $user, array $allUsers): bool
+    {
+        $grid = $room->getTiles();
+        foreach ($allUsers as $u) {
+            $grid[$u->getPosX()][$u->getPosY()]['color'] = $u->getDice()->getFrontColor();
+        }
+        $startX = $user->getPosX();
+        $startY = $user->getPosY();
+        $color  = $user->getDice()->getFrontColor();
+        $directions = [[1,0],[0,1],[1,1],[1,-1]];
+        foreach ($directions as [$dx,$dy]) {
+            $count = 1;
+            for ($i=1;$i<3;$i++) {
+                $nx = $startX + $dx*$i;
+                $ny = $startY + $dy*$i;
+                if (($grid[$nx][$ny]['color'] ?? null) === $color) {
+                    $count++;
+                } else {
+                    break;
+                }
+            }
+            if ($count >= 3) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Hidden rule #8 - placeholder always false */
+    public function hiddenEight(RoomDto $room, UserDto $user, array $allUsers): bool
+    {
+        return false;
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "vlucas/phpdotenv": "^5.6",
         "predis/predis": "^3.0",
-        "workerman/workerman": "^5.1"
+        "workerman/workerman": "^5.1",
+        "cboden/ratchet": "^0.4"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.13"

--- a/ratchet_server.php
+++ b/ratchet_server.php
@@ -1,0 +1,65 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use Ratchet\MessageComponentInterface;
+use Ratchet\ConnectionInterface;
+use Predis\Client;
+
+class GameSocket implements MessageComponentInterface
+{
+    private Client $redis;
+    private array $clients = [];
+
+    public function __construct(Client $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function onOpen(ConnectionInterface $conn)
+    {
+        $query = $conn->httpRequest->getUri()->getQuery();
+        parse_str($query, $params);
+        $conn->roomId = $params['roomId'] ?? '';
+        $conn->userId = $params['userId'] ?? '';
+        $this->clients[$conn->resourceId] = $conn;
+    }
+
+    public function onMessage(ConnectionInterface $from, $msg)
+    {
+        $data = @json_decode($msg, true);
+        if (!$data) {
+            return;
+        }
+        switch ($data['action'] ?? '') {
+            case 'subscribe':
+                $from->send(json_encode(['type' => 'subscribed']));
+                break;
+        }
+    }
+
+    public function onClose(ConnectionInterface $conn)
+    {
+        unset($this->clients[$conn->resourceId]);
+    }
+
+    public function onError(ConnectionInterface $conn, \Exception $e)
+    {
+        $conn->close();
+    }
+}
+
+$redis = new Client([
+    'host' => '127.0.0.1',
+    'port' => 6379
+]);
+
+$server = Ratchet\Server\IoServer::factory(
+    new Ratchet\Http\HttpServer(
+        new Ratchet\WebSocket\WsServer(
+            new GameSocket($redis)
+        )
+    ),
+    8080
+);
+
+$server->run();


### PR DESCRIPTION
## Summary
- add Ratchet dependency
- implement `GameService` with turn handling and move API
- add `RuleEngine` with hidden rule methods
- add simple Ratchet-based websocket server

## Testing
- `php` not available so syntax could not be checked

------
https://chatgpt.com/codex/tasks/task_e_68530f6064308325bc6fa4e127fd87ea