### PR TITLE
Implement game start and turn order

### DIFF
--- a/DAO/RoomDao.php
+++ b/DAO/RoomDao.php
@@ -32,7 +32,7 @@ class RoomDao
         }
 
         // 기본값 및 타입 변환
-        $state     = $data['state']   ?? '';
+        $started   = isset($data['started']) && $data['started'] !== '0';
         $width     = isset($data['width'])  ? (int)$data['width']  : 0;
         $height    = isset($data['height']) ? (int)$data['height'] : 0;
         $tilesJson = $data['tiles']   ?? '[]';
@@ -66,7 +66,7 @@ class RoomDao
 
         return new RoomDto(
             $roomId,
-            $state,
+            $started,
             $width,
             $height,
             $tiles,
@@ -101,7 +101,7 @@ class RoomDao
         $updatedStr = $dto->getUpdatedAt()->format(DateTimeInterface::ATOM);
 
         $this->redis->hmset($key, [
-            'state'      => $dto->getState(),
+            'started'    => $dto->isStarted() ? '1' : '0',
             'width'      => $dto->getWidth(),
             'height'     => $dto->getHeight(),
             'tiles'      => $tilesJson,

--- a/DTO/RoomDto.php
+++ b/DTO/RoomDto.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 class RoomDto
 {
     private int $roomId;
-    private string $state;
+    private bool $started;
     private int $width;
     private int $height;
     /**
@@ -25,7 +25,7 @@ class RoomDto
      */
     public function __construct(
         int $roomId,
-        string $state,
+        bool $started,
         int $width,
         int $height,
         array $tiles,
@@ -33,7 +33,7 @@ class RoomDto
         DateTimeInterface $updated_at
     ) {
         $this->roomId     = $roomId;
-        $this->state      = $state;
+        $this->started    = $started;
         $this->width      = $width;
         $this->height     = $height;
         $this->validateTiles($tiles);
@@ -47,9 +47,9 @@ class RoomDto
         return $this->roomId;
     }
 
-    public function getState(): string
+    public function isStarted(): bool
     {
-        return $this->state;
+        return $this->started;
     }
 
     public function getWidth(): int
@@ -126,7 +126,7 @@ class RoomDto
     {
         return [
             'room_id'    => $this->roomId,
-            'state'      => $this->state,
+            'started'    => $this->started,
             'width'      => $this->width,
             'height'     => $this->height,
             'tiles'      => array_map(fn(TileDto $t) => $t->toArray(), $this->tiles),

--- a/Service/Dice.php
+++ b/Service/Dice.php
@@ -58,9 +58,14 @@ class Dice
         $roomData = $redis->hgetall($roomKey);
 
 
-        //턴 체크
+        //턴 체크 및 게임 시작 여부 확인
         $turnUser = $redis->hget("room:{$roomId}:turn", "current_turn_user_id");
-        if ($roomData["state"] || $turnUser !== $userId) {
+        $started  = isset($roomData['started']) && $roomData['started'] !== '0';
+        if (!$started) {
+            http_response_code(403);
+            return ['error' => 'game not started'];
+        }
+        if ($turnUser !== $userId) {
             http_response_code(403);
             return ['error' => 'not your turn'];
         }

--- a/Service/turn.php
+++ b/Service/turn.php
@@ -42,10 +42,10 @@ class Turn
             return false;
         }
 
-        // roomData['state']가 false(게임 시작 전)이면 항상 true로 반환
-        if (isset($roomData['state']) && $roomData['state'] === 'false') {
-            echo json_encode(['is_my_turn' => true], JSON_UNESCAPED_UNICODE);
-            return true;
+        $started = isset($roomData['started']) && $roomData['started'] !== '0';
+        if (!$started) {
+            echo json_encode(['is_my_turn' => false], JSON_UNESCAPED_UNICODE);
+            return false;
         }
 
         $turnUserId = $redis->hget("room:{$roomId}:turn", "current_turn_user_id");

--- a/game.php
+++ b/game.php
@@ -19,6 +19,8 @@ if (!$room_id) {
     <h1>방 ID: <?= htmlspecialchars($room_id) ?></h1>
     <button onclick="location.href='index.php'">🔙 대기실로</button>
     <div id="board"></div>
+    <button id="startBtn">Start Game</button>
+    <div id="turn-order"></div>
 
     <script>
         let roomId = "<?= $room_id ?>";
@@ -49,6 +51,13 @@ if (!$room_id) {
                         room_id: roomId,
                         user_id: myUserId
                     }));
+                    document.getElementById('startBtn').onclick = () => {
+                        ws.send(JSON.stringify({
+                            action: 'start_game',
+                            room_id: roomId,
+                            user_id: myUserId
+                        }));
+                    };
                 };
 
                 ws.onmessage = (event) => {
@@ -65,6 +74,9 @@ if (!$room_id) {
                             // 주사위 렌더링
                             renderBoard(boardData);
                             renderUsers(msg.dices.player);
+                            break;
+                        case 'game_started':
+                            displayTurnOrder(msg.turn_order);
                             break;
                         case 'dice_moved':
                             // 한 사용자가 주사위 이동했을 때 해당 사용자 정보만 업데이트
@@ -192,8 +204,17 @@ if (!$room_id) {
         function getBoardWidth() {
             const board = document.getElementById('board');
             // grid-template-columns에서 px 정보 꺼내서 계산하거나, 서버에서 width를 전역 변수에 저장
-            // 여기서는 처음 renderBoard 할 때 전역 변수에 저장하는 방식으로 수정하는 게 깔끔 
+            // 여기서는 처음 renderBoard 할 때 전역 변수에 저장하는 방식으로 수정하는 게 깔끔
             return boardWidth || 0;
+        }
+
+        function displayTurnOrder(order) {
+            const el = document.getElementById('turn-order');
+            if (!order || order.length === 0) {
+                el.textContent = '';
+                return;
+            }
+            el.textContent = 'Turn: ' + order.join(' → ');
         }
 
         // 주사위 DOM 생성 및 드래그 이벤트 처리 (기존 createDiceElement 함수 수정)

--- a/server.php
+++ b/server.php
@@ -49,6 +49,15 @@ $ws_worker->onMessage = function (TcpConnection $conn, $data) use (&$ws_worker) 
             $conn->send(json_encode(['type' => 'board_data', 'board' => Room::getBoard($msg['room_id'])]));
             $conn->send(json_encode(['type' => 'dices_data', 'dices' => user::getDices($msg['room_id'])]));
             break;
+        case 'start_game':
+            $result = Room::startGame($msg['room_id']);
+            foreach ($ws_worker->connections as $c) {
+                if ($c->roomId === $msg['room_id']) {
+                    $c->send(json_encode(['type' => 'dices_data', 'dices' => User::getDices($msg['room_id'])]));
+                    $c->send(json_encode(['type' => 'game_started', 'turn_order' => $result['turn_order']]));
+                }
+            }
+            break;
         case 'move':
             Dice::move($msg['user_id'], $msg['room_id'], $msg['direction']);
             foreach ($ws_worker->connections as $c) {


### PR DESCRIPTION
## Summary
- add game start button and show turn order in UI
- rename `state` to `started` and update room creation
- implement `startGame` to initialize board state and shuffle turns
- handle start request and broadcast order to players
- enforce started state when moving dice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531e2b8f748325bd9daf7a2c146535