### PR TITLE
Improve WebSocket server resiliency

### DIFF
--- a/ratchet_server.php
+++ b/ratchet_server.php
@@ -1,6 +1,21 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
+set_error_handler(function ($level, $message, $file, $line) {
+    echo "[Error] {$message} in {$file}:{$line}\n";
+});
+
+set_exception_handler(function (Throwable $e) {
+    echo "[Exception] {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}\n";
+});
+
+register_shutdown_function(function () {
+    $error = error_get_last();
+    if ($error !== null) {
+        echo "[Fatal] {$error['message']} in {$error['file']}:{$error['line']}\n";
+    }
+});
+
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
 use Predis\Client;
@@ -17,29 +32,41 @@ class GameSocket implements MessageComponentInterface
 
     public function onOpen(ConnectionInterface $conn)
     {
-        $query = $conn->httpRequest->getUri()->getQuery();
-        parse_str($query, $params);
-        $conn->roomId = $params['roomId'] ?? '';
-        $conn->userId = $params['userId'] ?? '';
-        $this->clients[$conn->resourceId] = $conn;
+        try {
+            $query = $conn->httpRequest->getUri()->getQuery();
+            parse_str($query, $params);
+            $conn->roomId = $params['roomId'] ?? '';
+            $conn->userId = $params['userId'] ?? '';
+            $this->clients[$conn->resourceId] = $conn;
+        } catch (\Throwable $e) {
+            echo "[Open Exception] {$e->getMessage()}\n";
+        }
     }
 
     public function onMessage(ConnectionInterface $from, $msg)
     {
-        $data = @json_decode($msg, true);
-        if (!$data) {
-            return;
-        }
-        switch ($data['action'] ?? '') {
-            case 'subscribe':
-                $from->send(json_encode(['type' => 'subscribed']));
-                break;
+        try {
+            $data = @json_decode($msg, true);
+            if (!$data) {
+                return;
+            }
+            switch ($data['action'] ?? '') {
+                case 'subscribe':
+                    $from->send(json_encode(['type' => 'subscribed']));
+                    break;
+            }
+        } catch (\Throwable $e) {
+            echo "[Message Exception] {$e->getMessage()}\n";
         }
     }
 
     public function onClose(ConnectionInterface $conn)
     {
-        unset($this->clients[$conn->resourceId]);
+        try {
+            unset($this->clients[$conn->resourceId]);
+        } catch (\Throwable $e) {
+            echo "[Close Exception] {$e->getMessage()}\n";
+        }
     }
 
     public function onError(ConnectionInterface $conn, \Exception $e)


### PR DESCRIPTION
## Summary
- add global error/exception handlers for Workerman and Ratchet servers
- wrap WebSocket event callbacks with try/catch blocks
- log connection, message, and close errors to prevent server exit

## Testing
- `php -l server.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853271c1430832590e3a7fc42acb5e7