### PR TITLE
Implement start tile selection and turn order display

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,3 +155,27 @@ body {
   opacity: 0;
   transform: translateY(-20px);
 }
+
+#turn-order {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #999;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 14px;
+}
+
+#start-dice {
+  position: fixed;
+  top: 60px;
+  right: 10px;
+  width: 60px;
+  height: 60px;
+}
+
+.tile.selectable {
+  outline: 3px dashed #333;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- show turn order and start dice preview in the game UI
- hide start button once clicked
- refuse duplicate game start requests
- allow players to choose their start tile and dice orientation

## Testing
- `php -l Service/Room.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68534e61f7288325b1634e7e599c2beb