### PR TITLE
Implement start tile limits and dice setup

### DIFF
--- a/Helpers/DiceHelper.php
+++ b/Helpers/DiceHelper.php
@@ -53,9 +53,16 @@ class DiceHelper
     // 특정 위치가 유효한 타일(이동 가능)인지 검사
     public static function isValidTile(int $x, int $y, array $tiles): bool
     {
-        if ($tiles[$x][$y]['type'] !== 'start') {
-            return true;
+        // 좌표가 보드 범위를 벗어나면 이동 불가
+        if (!isset($tiles[$x][$y])) {
+            return false;
         }
-        return false;
+
+        // 게임 시작 후에는 start 타일로 이동할 수 없도록 제한
+        if (($tiles[$x][$y]['type'] ?? '') === 'start') {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent moving off the board in `DiceHelper`
- disallow joining a room when start tiles are full
- validate player count when starting the game
- show interactive dice on chosen start tile
- propagate join/start errors in server

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853521182548325b4db52c25b83d845