### PR TITLE
Update hidden rule movement logic

### DIFF
--- a/Service/Rule.php
+++ b/Service/Rule.php
@@ -71,7 +71,7 @@ class Rule
     }
 
     /**
-     * 5. 주변 9칸에 같은 색 윗면 말이 3개 이상일 때
+     * 5. 주변 9칸(자신 포함)에 같은 색 윗면 말이 3개 이상일 때
      *
      * @param RoomDto     $room
      * @param UserDto     $user
@@ -89,11 +89,12 @@ class Rule
         $center    = [$user->getPosX(), $user->getPosY()];
         $neighbors = $room->getNeighbors($center, 1);
         $frontColor  = $user->getDice()->getFrontColor();
-        $count     = 0;
+        $count     = 1; // 본인 포함
 
         foreach ($neighbors as [$x, $y]) {
             if (($grid[$x][$y]['color'] ?? null) === $frontColor) {
-                if (++$count >= 3) {
+                $count++;
+                if ($count >= 3) {
                     return true;
                 }
             }

--- a/Service/turn.php
+++ b/Service/turn.php
@@ -103,4 +103,19 @@ class Turn
 
         return $result;
     }
+
+    /**
+     * Append a new turn entry at the end of the turn order list.
+     *
+     * @param string                    $roomId
+     * @param array<string,string|null> $turn
+     * @return void
+     */
+    public function insertTurn(string $roomId, array $turn): void
+    {
+        $redis = getRedis();
+        $key   = "room:{$roomId}:turn_order";
+
+        $redis->rPush($key, json_encode($turn));
+    }
 }


### PR DESCRIPTION
## Summary
- adjust three-of-a-kind rule to include the player's own piece
- move only neighbouring matching pieces when rule triggers

## Testing
- `php -l Service/Dice.php` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6859b1d4ce5c83258e8d227ff4742e0f