### PR TITLE
Add goal rule and turn logging

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -2,3 +2,22 @@ CREATE TABLE IF NOT EXISTS map (
   map_id VARCHAR(20) PRIMARY KEY,
   board jsonb NOT NULL
 );
+
+-- 로그 테이블: 사용자 이동 턴
+CREATE TABLE IF NOT EXISTS move_turns (
+  id SERIAL PRIMARY KEY,
+  room_id VARCHAR(20) NOT NULL,
+  user_id VARCHAR(20) NOT NULL,
+  action VARCHAR(20) NOT NULL,
+  direction VARCHAR(10),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- 로그 테이블: 히든 룰로 추가된 턴
+CREATE TABLE IF NOT EXISTS hidden_turns (
+  id SERIAL PRIMARY KEY,
+  room_id VARCHAR(20) NOT NULL,
+  user_id VARCHAR(20) NOT NULL,
+  action VARCHAR(20) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/server.php
+++ b/server.php
@@ -102,6 +102,9 @@ $ws_worker->onMessage = function (TcpConnection $conn, $data) use (&$ws_worker) 
                         if ($result['exile'] ?? false) {
                             $c->send(json_encode(['type' => 'exiled', 'user' => $msg['user_id']]));
                         }
+                        if ($result['game_end'] ?? false) {
+                            $c->send(json_encode(['type' => 'game_end']));
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
## Summary
- log move turns and hidden rule turns separately
- implement goal tile handling that ends the game immediately
- push hidden rule turns to the front of the queue for DFS ordering
- notify clients when game ends

## Testing
- `php -l Service/Turn.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685efccbf8f4832588b81e885b2fac31