### PR TITLE
Fix hidden rule execution and exile mark count

### DIFF
--- a/Service/Dice.php
+++ b/Service/Dice.php
@@ -154,7 +154,7 @@ class Dice
             return Response::success(['game_end'     => $goalReached]);
         }
 
-        self::applyHiddenRules($roomId, $userId, $userStates, $userDtos, $tiles);
+        self::applyHiddenRules($roomId, $userId, $userStates, $userDtos);
         $userDtos = $dao->findAllByRoomId($roomId);
 
         // Redis 저장

--- a/Service/Rule.php
+++ b/Service/Rule.php
@@ -30,8 +30,6 @@ class Rule
         $cellColor = $cell['color'] ?? null;
 
         if ($frontColor === 'white' || $cellColor === 'white') {
-            $user->setExileMarkCount($user->getExileMarkCount() + 1);
-            $userDao->save($user);
             return true;
         }
 


### PR DESCRIPTION
## Summary
- fix parameter mismatch preventing hidden rules from running
- avoid double increment of `exile_mark_count`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca563f0c832594319574655e1ce3