### PR TITLE
Fix hidden exile rule logic

### DIFF
--- a/Service/Dice.php
+++ b/Service/Dice.php
@@ -154,7 +154,7 @@ class Dice
             return Response::success(['game_end'     => $goalReached]);
         }
 
-        self::applyHiddenRules($roomId, $userId, $userStates, $userDtos, $tiles);
+        self::applyHiddenRules($roomId, $userId, $userStates, $userDtos);
         $userDtos = $dao->findAllByRoomId($roomId);
 
         // Redis 저장
@@ -232,14 +232,17 @@ class Dice
                 continue;
             }
             if ($rule->isExileCondition($roomDto, $dto, $userDao)) {
+                echo "[Debug] user {$uid} is exiled\n";
                 $userStates[$uid]['pos_x'] = -1;
                 $userStates[$uid]['pos_y'] = -1;
                 $turnSvc->advanceHiddenTurn($roomId, [
                     'user'   => $uid,
                     'action' => 'setStartTile',
                 ]);
+                echo "[Debug] hidden turn added for {$uid}\n";
 
                 $exileCount = $redis->hIncrBy("room:{$roomId}:user:{$uid}", 'exile_mark_count', 1);
+                echo "[Debug] exile_mark_count={$exileCount}\n";
                 if ($exileCount >= 3) {
                     User::deleteUserData($uid,  $roomId);
                 } else {

--- a/Service/Rule.php
+++ b/Service/Rule.php
@@ -26,16 +26,19 @@ class Rule
     {
         $frontColor = $user->getDice()->getFrontColor();
 
-        $cell      = $room->getTiles()[$user->getPosX()][$user->getPosY()] ?? [];
-        $cellColor = $cell['color'] ?? null;
-
-        if ($frontColor === 'white' || $cellColor === 'white') {
-            $user->setExileMarkCount($user->getExileMarkCount() + 1);
-            $userDao->save($user);
-            return true;
+        $tileColor = null;
+        foreach ($room->getTiles() as $tile) {
+            if ($tile->getX() === $user->getPosX() && $tile->getY() === $user->getPosY()) {
+                $tileColor = $tile->getColor();
+                break;
+            }
         }
 
-        return false;
+        $isExile = $frontColor === 'white' || $tileColor === 'white';
+
+        echo "[Debug] isExileCondition user={$user->getUserId()} front={$frontColor} tile=" . ($tileColor ?? 'null') . " result=" . ($isExile ? 'true' : 'false') . "\n";
+
+        return $isExile;
     }
 
     /**


### PR DESCRIPTION
## Summary
- correct tile lookup in `isExileCondition`
- add debug output for exile condition and hidden turns

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ca563f0c832594319574655e1ce3